### PR TITLE
Fixes WC 3.x issue with licenses not getting recycled on renewal

### DIFF
--- a/src/Api/Update.php
+++ b/src/Api/Update.php
@@ -133,7 +133,7 @@ class Update {
 			}
 
 			$response->errors = $e->__toArray();
-			die( serialize( $response ) );
+			$this->send_data( $response );
 		}
 
 	}
@@ -157,7 +157,7 @@ class Update {
 		$data->package     = $api_product->get_download_url( $license );
 
 		// send data
-		die( serialize( $data ) );
+		$this->send_data( $data );
 
 	}
 
@@ -211,6 +211,22 @@ class Update {
 		$data->download_link = $api_product->get_download_url( $license );
 
 		// send data
-		die( serialize( $data ) );
+		$this->send_data( $data );
+	}
+
+	/**
+	 * Send API response back to client.
+	 *
+	 * @param array|object $data
+	 */
+	private function send_data( $data ) {
+		if ( isset( $_SERVER['HTTP_ACCEPT'] ) && 'application/json' === $_SERVER['HTTP_ACCEPT'] ) {
+			wp_send_json( $data );
+			exit;
+		}
+
+		header( 'Content-type: text/plain' );
+		echo serialize( $data );
+		exit;
 	}
 }

--- a/src/WooCommerce/Order.php
+++ b/src/WooCommerce/Order.php
@@ -150,14 +150,10 @@ class Order {
 					$_upgrading_key = apply_filters( 'lwp_order_upgrading_key', $_upgrading_key, $item, $order );
 
 					// search for renewal key
-                    if( ! $is_subscription_renewal ) {
-	                    $_renewing_key = false;
-	                    foreach ( $item['item_meta'] as $meta_key => $meta_value ) {
-		                    if ( $meta_key == '_renewing_key' ) {
-			                    $_renewing_key = $meta_value[0];
-		                    }
-	                    }
-                    }
+					if ( ! $is_subscription_renewal ) {
+						// search for renewal key
+						$_renewing_key = ! empty( $item['item_meta']['_renewing_key'] ) ? $item['item_meta']['_renewing_key'] : false;
+					}
 
 					// check on renewal
 					if ( $_renewing_key ) {

--- a/src/WooCommerce/Order.php
+++ b/src/WooCommerce/Order.php
@@ -89,7 +89,6 @@ class Order {
 
 
 				// fetch if it's an API license product
-				$is_api_product = false;
 				if ( $product->is_type( 'variation' ) ) {
 					$is_api_product = ( 'yes' === get_post_meta( $product->get_parent_id(), '_is_api_product_license', true ) );
 				} else {

--- a/src/WooCommerce/Renewal.php
+++ b/src/WooCommerce/Renewal.php
@@ -22,7 +22,7 @@ class Renewal {
 		// WooCommerce filters to make the renewal work
 		add_filter( 'woocommerce_add_cart_item', array( $this, 'add_cart_item' ), 10, 1 );
 		add_filter( 'woocommerce_get_cart_item_from_session', array( $this, 'get_cart_item_from_session' ), 10, 2 );
-		add_action( 'woocommerce_new_order_item', array( $this, 'order_item_meta' ), 10, 2 );
+		add_action( 'woocommerce_checkout_create_order_line_item', array( $this, 'order_item_meta' ), 10, 4 );
 	}
 
 	/**
@@ -95,7 +95,6 @@ class Renewal {
 			$discount         = ( $price / 100 ) * 30; // @todo this should become an option
 			$discounted_price = $price - $discount;
 
-
 			$cart_item['data']->set_price( $discounted_price );
 			$cart_item['data']->set_name( $cart_item['data']->get_name() . ' (' . __( 'Renewal', 'license-wp' ) . ')' );
 		}
@@ -127,12 +126,14 @@ class Renewal {
 	/**
 	 * order_item_meta function for storing the meta in the order line items
 	 *
-	 * @param int $item_id
-	 * @param array $values
+	 * @param \WC_Order_Item $item
+	 * @param string        $cart_item_key
+	 * @param array         $values
+	 * @param \WC_Order      $order
 	 */
-	public function order_item_meta( $item_id, $values ) {
+	public function order_item_meta( $item, $cart_item_key, $values, $order ) {
 		if ( isset( $values['renewing_key'] ) ) {
-			wc_add_order_item_meta( $item_id, __('_renewing_key', 'license-wp' ), $values['renewing_key'] );
+			$item->add_meta_data( __( '_renewing_key', 'license-wp' ), $values['renewing_key'], true );
 		}
 	}
 

--- a/src/WooCommerce/Upgrade.php
+++ b/src/WooCommerce/Upgrade.php
@@ -22,7 +22,7 @@ class Upgrade {
 		// WooCommerce filters to make the renewal work
 		add_filter( 'woocommerce_add_cart_item', array( $this, 'add_cart_item' ), 10, 1 );
 		add_filter( 'woocommerce_get_cart_item_from_session', array( $this, 'get_cart_item_from_session' ), 10, 2 );
-		add_action( 'woocommerce_new_order_item', array( $this, 'order_item_meta' ), 10, 2 );
+		add_action( 'woocommerce_checkout_create_order_line_item', array( $this, 'order_item_meta' ), 10, 2 );
 	}
 
 	/**
@@ -154,12 +154,14 @@ class Upgrade {
 	/**
 	 * order_item_meta function for storing the meta in the order line items
 	 *
-	 * @param int $item_id
-	 * @param array $values
+	 * @param \WC_Order_Item $item
+	 * @param string        $cart_item_key
+	 * @param array         $values
+	 * @param \WC_Order      $order
 	 */
-	public function order_item_meta( $item_id, $values ) {
+	public function order_item_meta( $item, $cart_item_key, $values, $order ) {
 		if ( isset( $values['upgrading_key'] ) ) {
-			wc_add_order_item_meta( $item_id, __( '_upgrading_key', 'license-wp' ), $values['upgrading_key'] );
+			$item->add_meta_data( __( '_upgrading_key', 'license-wp' ), $values['upgrading_key'], true );
 		}
 	}
 


### PR DESCRIPTION
Fixes #25

This update uses WC 3.x's new `woocommerce_checkout_create_order_line_item` action to add the renewing license key. It fixes the issue of licenses not getting recycled upon renewal or upgrade.

In `Never5\LicenseWP\WooCommerce\Order` I also simplified the retrieval of the meta key. I stopped treating it as an array as it was always just a string in my instance. This was preventing the updating of the old license.