### PR TITLE
 Handle subscription renewals and resubscriptions with licenses

### DIFF
--- a/src/Api/Update.php
+++ b/src/Api/Update.php
@@ -133,7 +133,7 @@ class Update {
 			}
 
 			$response->errors = $e->__toArray();
-			die( serialize( $response ) );
+			$this->send_data( $response );
 		}
 
 	}
@@ -157,7 +157,7 @@ class Update {
 		$data->package     = $api_product->get_download_url( $license );
 
 		// send data
-		die( serialize( $data ) );
+		$this->send_data( $data );
 
 	}
 
@@ -211,6 +211,22 @@ class Update {
 		$data->download_link = $api_product->get_download_url( $license );
 
 		// send data
-		die( serialize( $data ) );
+		$this->send_data( $data );
+	}
+
+	/**
+	 * Send API response back to client.
+	 *
+	 * @param array|object $data
+	 */
+	private function send_data( $data ) {
+		if ( isset( $_SERVER['HTTP_ACCEPT'] ) && 'application/json' === $_SERVER['HTTP_ACCEPT'] ) {
+			wp_send_json( $data );
+			exit;
+		}
+
+		header( 'Content-type: text/plain' );
+		echo serialize( $data );
+		exit;
 	}
 }

--- a/src/WooCommerce/Order.php
+++ b/src/WooCommerce/Order.php
@@ -89,7 +89,6 @@ class Order {
 
 
 				// fetch if it's an API license product
-				$is_api_product = false;
 				if ( $product->is_type( 'variation' ) ) {
 					$is_api_product = ( 'yes' === get_post_meta( $product->get_parent_id(), '_is_api_product_license', true ) );
 				} else {

--- a/src/WooCommerce/Upgrade.php
+++ b/src/WooCommerce/Upgrade.php
@@ -22,7 +22,7 @@ class Upgrade {
 		// WooCommerce filters to make the renewal work
 		add_filter( 'woocommerce_add_cart_item', array( $this, 'add_cart_item' ), 10, 1 );
 		add_filter( 'woocommerce_get_cart_item_from_session', array( $this, 'get_cart_item_from_session' ), 10, 2 );
-		add_action( 'woocommerce_new_order_item', array( $this, 'order_item_meta' ), 10, 2 );
+		add_action( 'woocommerce_checkout_create_order_line_item', array( $this, 'order_item_meta' ), 10, 2 );
 	}
 
 	/**
@@ -154,12 +154,14 @@ class Upgrade {
 	/**
 	 * order_item_meta function for storing the meta in the order line items
 	 *
-	 * @param int $item_id
-	 * @param array $values
+	 * @param \WC_Order_Item $item
+	 * @param string        $cart_item_key
+	 * @param array         $values
+	 * @param \WC_Order      $order
 	 */
-	public function order_item_meta( $item_id, $values ) {
+	public function order_item_meta( $item, $cart_item_key, $values, $order ) {
 		if ( isset( $values['upgrading_key'] ) ) {
-			wc_add_order_item_meta( $item_id, __( '_upgrading_key', 'license-wp' ), $values['upgrading_key'] );
+			$item->add_meta_data( __( '_upgrading_key', 'license-wp' ), $values['upgrading_key'], true );
 		}
 	}
 

--- a/templates/my-licenses.php
+++ b/templates/my-licenses.php
@@ -24,8 +24,8 @@ if ( sizeof( $licenses ) > 0 ) : ?>
 			$activations = $license->get_activations();
 			?>
 			<tr>
-				<td rowspan="<?php echo( ( ! $license->is_expired() ) ? sizeof( $activations ) + 1 : 1 ); ?>"><?php echo esc_html( $wc_product->post_title ); ?></td>
-				<td>
+				<td rowspan="<?php echo( ( ! $license->is_expired() ) ? sizeof( $activations ) + 1 : 1 ); ?>" class="lwp_licenses_name"><?php echo esc_html( $wc_product->post_title ); ?></td>
+				<td class="lwp_licenses_code">
 					<code style="display:block;"><?php echo $license->get_key(); ?></code>
 					<small>
 						<?php printf( __( 'Activation email: %s', 'license-wp' ), $license->get_activation_email() ); ?><br/>
@@ -38,7 +38,7 @@ if ( sizeof( $licenses ) > 0 ) : ?>
 						<?php endif; ?>
 					</small>
 				</td>
-				<td><?php
+				<td class="lwp_licenses_activation_limit"><?php
 					if ( $license->get_activation_limit() > 0 ) {
 						printf( __( '%d per product', 'license-wp' ), absint( $license->get_activation_limit() ) );
 
@@ -49,7 +49,7 @@ if ( sizeof( $licenses ) > 0 ) : ?>
 
 							// check if there are upgrade options available
 							if ( count( $license_options ) > 0 ) {
-								echo '<br/><a class="button" href="' . $license->get_upgrade_url() . '">' . __( 'Upgrade License', 'license-wp' ) . '</a>';
+								echo '<br/><a class="button lwp_button_upgrade" href="' . $license->get_upgrade_url() . '">' . __( 'Upgrade License', 'license-wp' ) . '</a>';
 							}
 						}
 
@@ -57,9 +57,9 @@ if ( sizeof( $licenses ) > 0 ) : ?>
 						_e( 'Unlimited', 'license-wp' );
 					}
 					?></td>
-				<td><?php
+				<td class="lwp_licenses_download"><?php
 					if ( $license->is_expired() ) {
-						echo '<a class="button" href="' . $license->get_renewal_url() . '">' . __( 'Renew License', 'license-wp' ) . '</a>';
+						echo '<a class="button lwp_button_renew" href="' . $license->get_renewal_url() . '">' . __( 'Renew License', 'license-wp' ) . '</a>';
 					} else {
 
 						// get API products
@@ -81,7 +81,7 @@ if ( sizeof( $licenses ) > 0 ) : ?>
 			/** @var \Never5\LicenseWP\Activation\Activation $activation */
 			?>
 			<tr>
-				<td colspan="3">
+				<td colspan="3" class="lwp_licenses_activation">
 					<?php echo get_the_title(  $activation->get_api_product_post_id() ); ?> &mdash; <a href="<?php echo esc_attr( $activation->get_instance() ); ?>" target="_blank"><?php echo esc_html( $activation->get_instance() ); ?></a> <a class="button" style="float:right" href="<?php echo $activation->get_deactivate_url($license); ?>"><?php _e( 'Deactivate', 'license-wp' ); ?></a>
 				</td>
 			</tr>


### PR DESCRIPTION
Fixes #27
Base PR #26

All PR changes in c5a8d3dce603cadd7ec7de3b5a4d5aac646690ff.

I refactored the WIP a bit to use the `wcs_get_subscriptions_for_order()` function. I'm fetching renewing subscriptions and resubscribing subscriptions separately so we can treat them differently (resubscribing shouldn't cause an extension of the expiration date). We can also move the `$_upgrading_key` bit to the same `$previous_license_keys` logic above (just need to translate all the filters).
  