### PR TITLE
Renewal should happen through subscription once tied

### DIFF
--- a/src/License/License.php
+++ b/src/License/License.php
@@ -2,6 +2,8 @@
 
 namespace Never5\LicenseWP\License;
 
+use Never5\LicenseWP\WooCommerce\Order;
+
 /**
  * Class License
  * @package Never5\LicenseWP\License
@@ -232,10 +234,26 @@ class License {
 	 * @return string
 	 */
 	public function get_renewal_url() {
-		return apply_filters( 'license_wp_license_renewal_url', add_query_arg( array(
+		$renewal_url = add_query_arg( array(
 			'renew_license'    => $this->get_key(),
 			'activation_email' => $this->get_activation_email()
-		), apply_filters( 'woocommerce_get_cart_url', wc_get_page_permalink( 'cart' ) ) ), $this );
+		), apply_filters( 'woocommerce_get_cart_url', wc_get_page_permalink( 'cart' ) ) );
+
+		$subscription = $this->get_subscription();
+		if ( $subscription ) {
+			$renewal_url = $subscription->get_view_order_url();
+		}
+
+		return apply_filters( 'license_wp_license_renewal_url', $renewal_url, $this, $subscription );
+	}
+
+	/**
+	 * Returns the subscription tied to this license.
+	 *
+	 * @return bool|\WC_Subscription
+	 */
+	public function get_subscription() {
+		return Order::get_order_subscription_for_product( $this->get_product_id(), $this->get_order_id() );
 	}
 
 	/**

--- a/src/WooCommerce/Order.php
+++ b/src/WooCommerce/Order.php
@@ -271,10 +271,10 @@ class Order {
 	}
 
 	/**
-	 * Returns the previous subscriptions (renewals or resubscriptions) tied to this order.
+	 * Returns the related subscriptions tied to this order.
 	 *
 	 * @param int               $order_id
-	 * @param string|array|null $order_type Order type for subscription query. Default (set to null) is `[ 'renewal', 'resubscribe' ]`.
+	 * @param string|array|null $order_type Order type for subscription query.
 	 *
 	 * @return array|bool
 	 */
@@ -282,9 +282,31 @@ class Order {
 		if ( ! class_exists( 'WC_Subscription' ) || ! function_exists( 'wcs_get_subscriptions_for_order' ) ) {
 			return false;
 		}
-		if ( null === $order_type ) {
-			$order_type = array( 'renewal', 'resubscribe' );
+		$args = array();
+		if ( null !== $order_type ) {
+			$args['order_type'] = $order_type;
 		}
-		return wcs_get_subscriptions_for_order( $order_id, array( 'order_type' => $order_type ) );
+		return wcs_get_subscriptions_for_order( $order_id, $args );
+	}
+
+	/**
+	 * Returns the related subscription tied to this order for a specific product.
+	 *
+	 * @param int               $product_id
+	 * @param int               $order_id
+	 * @param string|array|null $order_type Order type for subscription query.
+	 *
+	 * @return \WC_Subscription|bool
+	 */
+	public static function get_order_subscription_for_product( $product_id, $order_id, $order_type = null ) {
+		$subscriptions = self::get_order_subscriptions( $order_id, $order_type );
+		if ( ! empty( $subscriptions ) ) {
+			foreach ( $subscriptions as $subscription ) {
+				if ( $subscription->has_product( $product_id ) ) {
+					return $subscription;
+				}
+			}
+		}
+		return false;
 	}
 }

--- a/src/WooCommerce/Renewal.php
+++ b/src/WooCommerce/Renewal.php
@@ -20,9 +20,9 @@ class Renewal {
 		} );
 
 		// WooCommerce filters to make the renewal work
-		add_filter( 'woocommerce_add_cart_item', array( $this, 'add_cart_item' ), 10, 1 );
-		add_filter( 'woocommerce_get_cart_item_from_session', array( $this, 'get_cart_item_from_session' ), 10, 2 );
-		add_action( 'woocommerce_checkout_create_order_line_item', array( $this, 'order_item_meta' ), 10, 4 );
+		add_filter( 'woocommerce_add_cart_item', array( __CLASS__, 'add_cart_item' ), 10, 1 );
+		add_filter( 'woocommerce_get_cart_item_from_session', array( __CLASS__, 'get_cart_item_from_session' ), 10, 2 );
+		add_action( 'woocommerce_checkout_create_order_line_item', array( __CLASS__, 'order_item_meta' ), 10, 4 );
 	}
 
 	/**
@@ -89,7 +89,7 @@ class Renewal {
 	 *
 	 * @return array
 	 */
-	public function add_cart_item( $cart_item ) {
+	public static function add_cart_item( $cart_item ) {
 		if ( isset( $cart_item['renewing_key'] ) ) {
 			$price            = $cart_item['data']->get_price();
 			$discount         = ( $price / 100 ) * 30; // @todo this should become an option
@@ -109,7 +109,7 @@ class Renewal {
 	 *
 	 * @return array
 	 */
-	public function get_cart_item_from_session( $cart_item, $values ) {
+	public static function get_cart_item_from_session( $cart_item, $values ) {
 		if ( isset( $values['renewing_key'] ) ) {
 			$price            = $cart_item['data']->get_price();
 			$discount         = ( $price / 100 ) * 30;  // @todo this should become an option
@@ -131,7 +131,7 @@ class Renewal {
 	 * @param array         $values
 	 * @param \WC_Order      $order
 	 */
-	public function order_item_meta( $item, $cart_item_key, $values, $order ) {
+	public static function order_item_meta( $item, $cart_item_key, $values, $order ) {
 		if ( isset( $values['renewing_key'] ) ) {
 			$item->add_meta_data( __( '_renewing_key', 'license-wp' ), $values['renewing_key'], true );
 		}

--- a/src/WooCommerce/Renewal.php
+++ b/src/WooCommerce/Renewal.php
@@ -56,6 +56,13 @@ class Renewal {
 			wc_add_notice( __( 'Invalid activation email address.', 'license-wp' ) );
 		}
 
+		$subscription = $license->get_subscription();
+		if ( $subscription ) {
+			wp_redirect( $subscription->get_view_order_url() );
+
+			return;
+		}
+
 		// get WooCommerce product
 		$product = wc_get_product( $license->get_product_id() );
 


### PR DESCRIPTION
Let me know what you think of this. Feel free to make suggestions.

Changes proposed:
- I made the filter methods for `Never5\LicenseWP\WooCommerce\Renewal` static for easier overriding (wouldn't be necessary if there is a universal solution to #30).
- When a license is tied to a subscription, direct the user to manage the subscription instead of creating a new renewal order. 

Here is an example of what I did after removing those hooks for an all-subscription environment. I didn't put this in here because it isn't super clean (especially when you have subscriptions at different intervals), but it works for our instance. There is probably a better way to do this. I'm also converting our old products to subscription products so I'm checking to see if they're migrating their license from the old product to the new subscription and giving them the discount.
```php
use Never5\LicenseWP\WooCommerce\Renewal;

add_action( 'wp_loaded', function() {
	remove_filter( 'woocommerce_add_cart_item', array( Renewal::class, 'add_cart_item' ), 10 );
	remove_filter( 'woocommerce_get_cart_item_from_session', array( Renewal::class, 'get_cart_item_from_session' ), 10 );

	add_filter( 'woocommerce_cart_calculate_fees', function ( WC_Cart $cart ) {
		$total = 0;
		$has_legacy_renewing_key = false;

		foreach ( WC()->cart->cart_contents as $cart_item ) {
			if ( WC_Subscriptions_Product::is_subscription( $cart_item['data'] ) ) {
				$total += $cart_item['data']->get_price();
			}
			if ( ! empty( $cart_item['renewing_key'] ) ) {
				$has_legacy_renewing_key = true;
			}
		}
		if ( $total > 0 && ( ! empty( $cart->recurring_cart_key ) || $has_legacy_renewing_key ) ) {
			$cart->add_fee( 'Renewal Discount (30%)', -1 * ( .3 * $total ) );
		}

	}, 10, 1 );

} );
```