### PR TITLE
Expire license at the end of the expiration day

### DIFF
--- a/src/License/License.php
+++ b/src/License/License.php
@@ -150,9 +150,10 @@ class License {
 	 * @return bool
 	 */
 	public function is_expired() {
+		$start_of_day = ( new \DateTime() )->setTime( 0, 0, 0 );
 
 		// check if license expired
-		if ( $this->get_date_expires() && $this->get_date_expires() < new \DateTime() ) {
+		if ( $this->get_date_expires() && $this->get_date_expires() < $start_of_day ) {
 			return true;
 		}
 


### PR DESCRIPTION
Fixes #32

This changes the current expiration behavior so that licenses expire at the end of the day. 