### PR TITLE
URL encode license key and activation email in URLs

### DIFF
--- a/src/Activation/Activation.php
+++ b/src/Activation/Activation.php
@@ -153,8 +153,8 @@ class Activation {
 	public function get_deactivate_url( $license ) {
 		return esc_url( add_query_arg( array(
 			'deactivate_license' => $this->get_id(),
-			'license_key'        => $license->get_key(),
-			'activation_email'   => $license->get_activation_email()
+			'license_key'        => urlencode( $license->get_key() ),
+			'activation_email'   => urlencode( $license->get_activation_email() ),
 		) ) );
 	}
 

--- a/src/ApiProduct/ApiProduct.php
+++ b/src/ApiProduct/ApiProduct.php
@@ -239,8 +239,8 @@ class ApiProduct {
 	public function get_download_url( $license ) {
 		return add_query_arg( array(
 			'download_api_product' => $this->get_id(),
-			'license_key'          => $license->get_key(),
-			'activation_email'     => $license->get_activation_email()
+			'license_key'          => urlencode( $license->get_key() ),
+			'activation_email'     => urlencode( $license->get_activation_email() ),
 		), home_url( '/' ) );
 	}
 }

--- a/src/License/License.php
+++ b/src/License/License.php
@@ -259,8 +259,8 @@ class License {
 	 */
 	public function get_renewal_url() {
 		return apply_filters( 'license_wp_license_renewal_url', add_query_arg( array(
-			'renew_license'    => $this->get_key(),
-			'activation_email' => $this->get_activation_email()
+			'renew_license'    => urlencode( $this->get_key() ),
+			'activation_email' => urlencode( $this->get_activation_email() ),
 		), apply_filters( 'woocommerce_get_cart_url', wc_get_page_permalink( 'cart' ) ) ), $this );
 	}
 
@@ -273,7 +273,7 @@ class License {
 		$page = get_page_by_title( apply_filters( 'license_wp_license_upgrade_page_title', 'upgrade license' ) );
 
 		return apply_filters( 'license_wp_license_upgrade_url', add_query_arg( array(
-			'license_key' => $this->get_key()
+			'license_key' => urlencode( $this->get_key() ),
 		), get_permalink( $page->ID ) ) );
 	}
 


### PR DESCRIPTION
This fixes an issue that was occurring when a user had an email like `jane+licensewp@example.com`.