### PR TITLE
My Account - Fix missing scheme on link to instance

### DIFF
--- a/templates/my-licenses.php
+++ b/templates/my-licenses.php
@@ -82,7 +82,7 @@ if ( sizeof( $licenses ) > 0 ) : ?>
 			?>
 			<tr>
 				<td colspan="3" class="lwp_licenses_activation">
-					<?php echo get_the_title(  $activation->get_api_product_post_id() ); ?> &mdash; <a href="<?php echo esc_attr( $activation->get_instance() ); ?>" target="_blank"><?php echo esc_html( $activation->get_instance() ); ?></a> <a class="button" style="float:right" href="<?php echo $activation->get_deactivate_url($license); ?>"><?php _e( 'Deactivate', 'license-wp' ); ?></a>
+					<?php echo get_the_title(  $activation->get_api_product_post_id() ); ?> &mdash; <a href="http://<?php echo esc_attr( $activation->get_instance() ); ?>" target="_blank"><?php echo esc_html( $activation->get_instance() ); ?></a> <a class="button" style="float:right" href="<?php echo $activation->get_deactivate_url($license); ?>"><?php _e( 'Deactivate', 'license-wp' ); ?></a>
 				</td>
 			</tr>
 		<?php endforeach; ?>


### PR DESCRIPTION
The missing scheme causes major browsers to treat this as a relative link.